### PR TITLE
Add gracc-reprocess tool

### DIFF
--- a/gracc-correct/requirements.txt
+++ b/gracc-correct/requirements.txt
@@ -1,0 +1,1 @@
+elasticsearch > 5.0.0

--- a/gracc-reprocess/README.md
+++ b/gracc-reprocess/README.md
@@ -59,7 +59,7 @@ See the alias example below for more information on usage of those arguments.
 $./gracc-reprocess -pq --size 100 gracc.osg.raw3-2017.06 http://localhost:8888/gracc
 2017-06-17 13:46:23,951 [UBER __main__] Processing index gracc.osg.raw3-2017.06
 2017-06-17 13:46:23,973 [UBER __main__] Processing 15500 records
-100% (15500 of 15500) |################################################################################################################################################| Elapsed Time: 0:01:31 ETA:  0:00:00
+100% (15500 of 15500) |########################| Elapsed Time: 0:01:31 ETA:  0:00:00
 2017-06-17 13:47:55,818 [UBER __main__] Processing complete. Sent 15500/15500 records
 ```
 
@@ -95,7 +95,8 @@ health status index                      uuid                   pri rep docs.cou
 $ ./gracc-reprocess -pq --size 100 --query 'ProbeName:"condor:fifebatch1.fnal.gov"' 'gracc.osg.raw3-*' http://localhost:8888/gracc
 2017-06-17 13:54:14,796 [UBER __main__] Processing index gracc.osg.raw3-2017.06
 2017-06-17 13:54:14,876 [UBER __main__] Processing 2279 records
-100% (2279 of 2279) |##################################################################################################################################################| Elapsed Time: 0:00:14 ETA:  0:00:002017-06-17 13:54:30,190 [UBER __main__] Processing complete. Sent 2279/2279 records
+100% (2279 of 2279) |##########################| Elapsed Time: 0:00:14 ETA:  0:00:00
+2017-06-17 13:54:30,190 [UBER __main__] Processing complete. Sent 2279/2279 records
 ```
 
 ### Reprocess and update alias
@@ -117,7 +118,8 @@ gracc.test.raw-2017.06 gracc.test.raw2-2017.06 -      -             -
 $ ./gracc-reprocess --size 100 -pq --close --alias --new_ver 3 gracc.test.raw2-2017.06 http://localhost:8888/gracc
 2017-06-17 14:06:50,536 [UBER __main__] Processing index gracc.test.raw2-2017.06
 2017-06-17 14:06:50,562 [UBER __main__] Processing 2500 records
-100% (2500 of 2500) |##################################################################################################################################################| Elapsed Time: 0:00:14 ETA:  0:00:002017-06-17 14:07:06,346 [UBER __main__] Processing complete. Sent 2500/2500 records
+100% (2500 of 2500) |##########################| Elapsed Time: 0:00:14 ETA:  0:00:00
+2017-06-17 14:07:06,346 [UBER __main__] Processing complete. Sent 2500/2500 records
 2017-06-17 14:07:06,346 [UBER __main__] moving alias gracc.test.raw-2017.06 from gracc.test.raw2-2017.06 to gracc.test.raw3-2017.06
 2017-06-17 14:07:06,876 [UBER __main__] Closing index gracc.test.raw2-2017.06
 

--- a/gracc-reprocess/README.md
+++ b/gracc-reprocess/README.md
@@ -1,0 +1,127 @@
+# gracc-reprocess
+
+Read raw records from Elasticsearch and send them to
+a GRACC Collector. Expects that records have a `RawXML` 
+field with the original XML record.
+
+## Installation
+
+`gracc-reprocess` requires Python 2.7 and the following packages:
+
+* elasticsearch (> 5.0)
+* requests
+* progressbar2
+
+Clone the `gracc-tools` repo or [download the zip archive](https://github.com/opensciencegrid/gracc-tools/archive/master.zip).
+To install the requirements with `pip`:
+
+```
+pip install -r requirements.txt
+```
+
+## Usage
+
+```
+$ ./gracc-reprocess -h
+usage: gracc-reprocess [-h] [--size SIZE] [--timeout TIMEOUT] [--debug] [-q]
+                       [-p] [--close] [--query QUERY] [--alias]
+                       [--alias_regex ALIAS_REGEX] [--new_ver NEW_VER]
+                       index url
+
+Reprocess GRACC records through collector
+
+positional arguments:
+  index                 source index pattern
+  url                   GRACC collector URL
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --size SIZE           Record batch size (default 500)
+  --timeout TIMEOUT     Elasticsearch timeout (default 300)
+  --debug               Enable debug logging
+  -q, --quiet           Disable most logging (ignored if --debug specified)
+  -p, --progress        Display progressbar
+  --close               Close index when done processing
+  --query QUERY         Limit reporecessed records by query_string
+  --alias               Move alias when done processing
+  --alias_regex ALIAS_REGEX
+                        RE to extract index prefix and date (for alias)
+  --new_ver NEW_VER     Version of new indices (for alias)
+```
+
+See the alias example below for more information on usage of those arguments.
+
+## Examples
+
+### Reprocess a single index
+
+```
+$./gracc-reprocess -pq --size 100 gracc.osg.raw3-2017.06 http://localhost:8888/gracc
+2017-06-17 13:46:23,951 [UBER __main__] Processing index gracc.osg.raw3-2017.06
+2017-06-17 13:46:23,973 [UBER __main__] Processing 15500 records
+100% (15500 of 15500) |################################################################################################################################################| Elapsed Time: 0:01:31 ETA:  0:00:00
+2017-06-17 13:47:55,818 [UBER __main__] Processing complete. Sent 15500/15500 records
+```
+
+### Reprocess and close when done
+
+```
+$ curl 'localhost:9200/_cat/indices?v'
+health status index                      uuid                   pri rep docs.count docs.deleted store.size pri.store.size
+yellow open   gracc.test.raw3-2006.06    mQlg3nAQSGGwJZC3H5g91A   3   1        174            0    286.5kb        286.5kb
+
+$ ./gracc-reprocess --close  gracc.test.raw3-2006.06 http://localhost:8888/gracc
+2017-06-17 13:51:14,654 [INFO requests.packages.urllib3.connectionpool] Starting new HTTP connection (1): localhost
+2017-06-17 13:51:14,659 [INFO elasticsearch] GET http://localhost:9200/gracc.test.raw3-2006.06/_settings [status:200 request:0.018s]
+2017-06-17 13:51:14,659 [UBER __main__] Processing index gracc.test.raw3-2006.06
+2017-06-17 13:51:14,676 [INFO elasticsearch] GET http://localhost:9200/gracc.test.raw3-2006.06/_search?size=500&scroll=5m&_source=RawXML [status:200 request:0.015s]
+2017-06-17 13:51:14,679 [UBER __main__] Processing 174 records
+2017-06-17 13:51:14,845 [INFO requests.packages.urllib3.connectionpool] Starting new HTTP connection (1): localhost
+2017-06-17 13:51:15,606 [INFO __main__] sent 174/174 records
+2017-06-17 13:51:15,634 [INFO elasticsearch] GET http://localhost:9200/_search/scroll?scroll=5m [status:200 request:0.028s]
+2017-06-17 13:51:15,634 [UBER __main__] Processing complete. Sent 174/174 records
+2017-06-17 13:51:15,634 [UBER __main__] Closing index gracc.test.raw3-2006.06
+2017-06-17 13:51:17,645 [INFO elasticsearch] POST http://localhost:9200/gracc.test.raw3-2006.06/_close [status:200 request:2.010s]
+
+
+$ curl 'localhost:9200/_cat/indices?v'
+health status index                      uuid                   pri rep docs.count docs.deleted store.size pri.store.size
+       close  gracc.test.raw3-2006.06    mQlg3nAQSGGwJZC3H5g91A                                                          
+```
+
+### Reprocess records matching query
+
+```
+$ ./gracc-reprocess -pq --size 100 --query 'ProbeName:"condor:fifebatch1.fnal.gov"' 'gracc.osg.raw3-*' http://localhost:8888/gracc
+2017-06-17 13:54:14,796 [UBER __main__] Processing index gracc.osg.raw3-2017.06
+2017-06-17 13:54:14,876 [UBER __main__] Processing 2279 records
+100% (2279 of 2279) |##################################################################################################################################################| Elapsed Time: 0:00:14 ETA:  0:00:002017-06-17 13:54:30,190 [UBER __main__] Processing complete. Sent 2279/2279 records
+```
+
+### Reprocess and update alias
+
+The `--alias` option is intended for migrating raw data to a new schema/checksum.
+
+`alias_regex` needs to match the index pattern and have two capture groups. The
+first is index & alias prefix, the second is the date component. The default is 
+`'(.*)\d-(\d\d\d\d\.\d\d)'`, which will work for GRACC monthly indices.
+
+`--new_ver` is the schema version number, e.g. `gracc.osg.raw3-*` is schema version 3.
+This is set by the `gracc-stash-raw` agent.
+
+```
+$ curl 'localhost:9200/_cat/aliases?v'
+alias                  index                   filter routing.index routing.search
+gracc.test.raw-2017.06 gracc.test.raw2-2017.06 -      -             -
+
+$ ./gracc-reprocess --size 100 -pq --close --alias --new_ver 3 gracc.test.raw2-2017.06 http://localhost:8888/gracc
+2017-06-17 14:06:50,536 [UBER __main__] Processing index gracc.test.raw2-2017.06
+2017-06-17 14:06:50,562 [UBER __main__] Processing 2500 records
+100% (2500 of 2500) |##################################################################################################################################################| Elapsed Time: 0:00:14 ETA:  0:00:002017-06-17 14:07:06,346 [UBER __main__] Processing complete. Sent 2500/2500 records
+2017-06-17 14:07:06,346 [UBER __main__] moving alias gracc.test.raw-2017.06 from gracc.test.raw2-2017.06 to gracc.test.raw3-2017.06
+2017-06-17 14:07:06,876 [UBER __main__] Closing index gracc.test.raw2-2017.06
+
+$ curl 'localhost:9200/_cat/aliases?v'
+alias                  index                   filter routing.index routing.search
+gracc.test.raw-2017.06 gracc.test.raw3-2017.06 -      -             -
+```

--- a/gracc-reprocess/gracc-reprocess
+++ b/gracc-reprocess/gracc-reprocess
@@ -22,12 +22,15 @@ logger = logging.getLogger(__name__)
 
 
 class Processor(object):
-    def __init__(self, index, url, size=500, close=False, timeout=60, progress=False, alias=False, alias_regex=None, new_ver=None):
+    def __init__(self, index, url, size=500, close=False, timeout=60, progress=False, query=None,
+                 alias=False, alias_regex=None, new_ver=None):
         self.index = index
         self.url = url
         self.size = size
         self.close = close
         self.progress = progress
+
+        self.query = query
 
         self.alias = alias
         self.alias_regex = re.compile(alias_regex)
@@ -49,29 +52,34 @@ class Processor(object):
     def process_index(self,index):
         s = self.client.search(index=index,
                 _source=["RawXML"],
+                q=self.query,
                 scroll="5m",
                 size=self.size)
         all_hits = s['hits']['total']
-        logger.log(99,'Processing %d recordss'%all_hits)
-        if self.progress:
-            bar = progressbar.ProgressBar(max_value=all_hits,redirect_stdout=True)
+        if all_hits > 0:
+            logger.log(99,'Processing %d records'%all_hits)
+            if self.progress:
+                bar = progressbar.ProgressBar(max_value=all_hits,redirect_stdout=True)
 
-        self.send_records(s['hits']['hits'])
-        sent_hits = len(s['hits']['hits'])
-        logger.info('sent %d/%d records'%(sent_hits,all_hits))
-        if self.progress:
-            bar.update(sent_hits)
-
-        while True:
-            s = self.client.scroll(scroll_id=s['_scroll_id'],scroll="5m")
-            if len(s['hits']['hits']) == 0:
-                break
             self.send_records(s['hits']['hits'])
-            sent_hits += len(s['hits']['hits'])
+            sent_hits = len(s['hits']['hits'])
             logger.info('sent %d/%d records'%(sent_hits,all_hits))
             if self.progress:
                 bar.update(sent_hits)
-        logger.log(99,'Processing complete. Sent %d/%d records'%(sent_hits,all_hits))
+
+            while True:
+                s = self.client.scroll(scroll_id=s['_scroll_id'],scroll="5m")
+                if len(s['hits']['hits']) == 0:
+                    break
+                self.send_records(s['hits']['hits'])
+                sent_hits += len(s['hits']['hits'])
+                logger.info('sent %d/%d records'%(sent_hits,all_hits))
+                if self.progress:
+                    bar.update(sent_hits)
+            logger.log(99,'Processing complete. Sent %d/%d records'%(sent_hits,all_hits))
+        else:
+            logger.log(99,'No records found')
+
         if self.alias:
             match=self.alias_regex.match(index)
             if not match:
@@ -86,6 +94,7 @@ class Processor(object):
                     self.client.indices.delete_alias(index=index,name=alias)
                 except elasicsearch.NotFoundError:
                     logger.warning('old alias does not exist to delete')
+
         if self.close:
             logger.log(99,'Closing index %s'%index)
             self.client.indices.close(index)
@@ -121,15 +130,19 @@ if __name__=="__main__":
     parser = ArgumentParser(description='Reprocess GRACC records through collector')
     parser.add_argument('index',help='source index pattern')
     parser.add_argument('url',help='GRACC collector URL')
+
     parser.add_argument('--size',help='Record batch size (default 500)',default=500,type=int)
     parser.add_argument('--timeout',help='Elasticsearch timeout (default 300)',default=300,type=int)
     parser.add_argument('--debug',help='Enable debug logging',action='store_true')
     parser.add_argument('-q','--quiet',help='Disable most logging (ignored if --debug specified)',action='store_true')
+    parser.add_argument('-p','--progress',help='Display progressbar',action='store_true')
+
     parser.add_argument('--close',help='Close index when done processing',action='store_true')
+    parser.add_argument('--query',help='Limit reporecessed records by query_string',type=str,default=None)
+
     parser.add_argument('--alias',help='Move alias when done processing',action='store_true')
     parser.add_argument('--alias_regex',help='RE to extract index prefix and date (for alias)',default=r'(.*)\d-(\d\d\d\d\.\d\d)')
     parser.add_argument('--new_ver',help='Version of new indices (for alias)')
-    parser.add_argument('-p','--progress',help='Display progressbar',action='store_true')
 
     args = parser.parse_args()
 
@@ -158,5 +171,6 @@ if __name__=="__main__":
                           alias=args.alias,
                           alias_regex=args.alias_regex,
                           new_ver=args.new_ver,
-                          progress=args.progress)
+                          progress=args.progress,
+                          query=args.query)
     processor.process()

--- a/gracc-reprocess/gracc-reprocess
+++ b/gracc-reprocess/gracc-reprocess
@@ -1,0 +1,151 @@
+#!/bin/env python
+"""
+Reprocess records by extracting original XML and sending them
+back through the GRACC collector.
+
+* Get records from Elasticsearch indices
+* extract original XML
+* package into bundles
+* send to collector
+"""
+
+from argparse import ArgumentParser
+import logging
+import requests
+import traceback
+import sys
+import re
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+import progressbar
+
+logger = logging.getLogger(__name__)
+
+
+class Processor(object):
+    def __init__(self, index, url, size=500, close=False, timeout=60, alias=False, alias_regex=None, new_ver=None):
+        self.index = index
+        self.url = url
+        self.size = size
+        self.close = close
+
+        self.alias = alias
+        self.alias_regex = re.compile(alias_regex)
+        self.new_ver = new_ver
+
+        self.client = Elasticsearch(timeout=timeout,connection_class=RequestsHttpConnection)
+
+    def process(self):
+        for idx in self.get_indices(self.index):
+            try:
+                logger.log(99,'Processing index %s'%idx)
+                self.process_index(idx)
+            except:
+                logger.error('Exception while processing index %s'%idx)
+                traceback.print_exc()
+                continue
+
+    def process_index(self,index):
+        s = self.client.search(index=index, 
+                _source=["RawXML"],
+                scroll="5m",
+                size=self.size)
+        all_hits = s['hits']['total']
+        logger.log(99,'Processing %d recordss'%all_hits)
+        bar = progressbar.ProgressBar(max_value=all_hits,redirect_stdout=True)
+
+        self.send_records(s['hits']['hits'])
+        sent_hits = len(s['hits']['hits'])
+        logger.info('sent %d/%d records'%(sent_hits,all_hits))
+        bar.update(sent_hits)
+
+        while True:
+            s = self.client.scroll(scroll_id=s['_scroll_id'],scroll="5m")
+            if len(s['hits']['hits']) == 0:
+                break
+            self.send_records(s['hits']['hits'])
+            sent_hits += len(s['hits']['hits'])
+            logger.info('sent %d/%d records'%(sent_hits,all_hits))
+            bar.update(sent_hits)
+        logger.log(99,'Processing complete. Sent %d/%d records'%(sent_hits,all_hits))
+        if self.alias:
+            match=self.alias_regex.match(index)
+            if not match:
+                logger.error('index [%s] does not match expected regex [%s], not updating alias'%(index,self.alias_regex.pattern))
+            else:
+                pre,post=match.groups()
+                alias='%s-%s'%(pre,post)
+                new='%s%s-%s'%(pre,self.new_ver,post)
+                logger.log(99,'moving alias %s from %s to %s'%(alias,index,new))
+                self.client.indices.put_alias(index=new,name=alias)
+                try:
+                    self.client.indices.delete_alias(index=index,name=alias)
+                except elasicsearch.NotFoundError:
+                    logger.warning('old alias does not exist to delete')
+        if self.close:
+            logger.log(99,'Closing index %s'%index)
+            self.client.indices.close(index)
+
+
+
+    def get_indices(self, index_pattern):
+        idxs = self.client.indices.get_settings(index=index_pattern)
+        return idxs.keys()
+
+    def make_bundle(self, r):
+        b = ''
+        for s in r:
+            b += 'replication|%s|%s||' % (s['_source']['RawXML'],s['_source']['RawXML'])
+        return b
+
+    def send_records(self, r):
+        b = self.make_bundle(r)
+        p = {
+            'command': 'update',
+            'from': 'gracc-reprocess',
+            'bundlesize': len(r),
+            'arg1': b,
+        }
+        url = self.url.rstrip('/')+'/gratia-servlets/rmi'
+
+        logger.debug('Posting bundle to URL %s\n%s'%(url,p))
+        res = requests.post(url, data=p)
+        res.raise_for_status()
+
+
+if __name__=="__main__":
+    parser = ArgumentParser(description='Reprocess GRACC records through collector')
+    parser.add_argument('index',help='source index pattern')
+    parser.add_argument('url',help='GRACC collector URL')
+    parser.add_argument('--size',help='Record batch size (default 500)',default=500,type=int)
+    parser.add_argument('--timeout',help='Elasticsearch timeout (default 300)',default=300,type=int)
+    parser.add_argument('--debug',help='Enable debug logging',action='store_true')
+    parser.add_argument('--quiet',help='Disable most logging (ignored if --debug specified)',action='store_true')
+    parser.add_argument('--close',help='Close index when done processing',action='store_true')
+    parser.add_argument('--alias',help='Move alias when done processing',action='store_true')
+    parser.add_argument('--alias_regex',help='RE to extract index prefix and date (for alias)',default=r'(.*)\d-(\d\d\d\d\.\d\d)')
+    parser.add_argument('--new_ver',help='Version of new indices (for alias)')
+
+    args = parser.parse_args()
+    
+    logfmt = "%(asctime)s [%(levelname)s %(name)s] %(message)s"
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG, format=logfmt)
+    elif args.quiet:
+        logging.basicConfig(level=logging.ERROR, format=logfmt)
+    else:
+        logging.basicConfig(level=logging.INFO, format=logfmt)
+    logging.addLevelName(99,'UBER')
+
+    if args.alias and args.new_ver is None:
+        logger.error('must specify --new_ver with --alias')
+        sys.exit(1)
+
+    processor = Processor(index=args.index,
+            url=args.url,
+            size=args.size,
+            close=args.close,
+            timeout=args.timeout,
+            alias=args.alias,
+            alias_regex=args.alias_regex,
+            new_ver=args.new_ver)
+    processor.process()

--- a/gracc-reprocess/gracc-reprocess
+++ b/gracc-reprocess/gracc-reprocess
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 Reprocess records by extracting original XML and sending them
 back through the GRACC collector.
@@ -22,15 +22,17 @@ logger = logging.getLogger(__name__)
 
 
 class Processor(object):
-    def __init__(self, index, url, size=500, close=False, timeout=60, alias=False, alias_regex=None, new_ver=None):
+    def __init__(self, index, url, size=500, close=False, timeout=60, progress=False, alias=False, alias_regex=None, new_ver=None):
         self.index = index
         self.url = url
         self.size = size
         self.close = close
+        self.progress = progress
 
         self.alias = alias
         self.alias_regex = re.compile(alias_regex)
         self.new_ver = new_ver
+
 
         self.client = Elasticsearch(timeout=timeout,connection_class=RequestsHttpConnection)
 
@@ -45,18 +47,20 @@ class Processor(object):
                 continue
 
     def process_index(self,index):
-        s = self.client.search(index=index, 
+        s = self.client.search(index=index,
                 _source=["RawXML"],
                 scroll="5m",
                 size=self.size)
         all_hits = s['hits']['total']
         logger.log(99,'Processing %d recordss'%all_hits)
-        bar = progressbar.ProgressBar(max_value=all_hits,redirect_stdout=True)
+        if self.progress:
+            bar = progressbar.ProgressBar(max_value=all_hits,redirect_stdout=True)
 
         self.send_records(s['hits']['hits'])
         sent_hits = len(s['hits']['hits'])
         logger.info('sent %d/%d records'%(sent_hits,all_hits))
-        bar.update(sent_hits)
+        if self.progress:
+            bar.update(sent_hits)
 
         while True:
             s = self.client.scroll(scroll_id=s['_scroll_id'],scroll="5m")
@@ -65,7 +69,8 @@ class Processor(object):
             self.send_records(s['hits']['hits'])
             sent_hits += len(s['hits']['hits'])
             logger.info('sent %d/%d records'%(sent_hits,all_hits))
-            bar.update(sent_hits)
+            if self.progress:
+                bar.update(sent_hits)
         logger.log(99,'Processing complete. Sent %d/%d records'%(sent_hits,all_hits))
         if self.alias:
             match=self.alias_regex.match(index)
@@ -119,14 +124,19 @@ if __name__=="__main__":
     parser.add_argument('--size',help='Record batch size (default 500)',default=500,type=int)
     parser.add_argument('--timeout',help='Elasticsearch timeout (default 300)',default=300,type=int)
     parser.add_argument('--debug',help='Enable debug logging',action='store_true')
-    parser.add_argument('--quiet',help='Disable most logging (ignored if --debug specified)',action='store_true')
+    parser.add_argument('-q','--quiet',help='Disable most logging (ignored if --debug specified)',action='store_true')
     parser.add_argument('--close',help='Close index when done processing',action='store_true')
     parser.add_argument('--alias',help='Move alias when done processing',action='store_true')
     parser.add_argument('--alias_regex',help='RE to extract index prefix and date (for alias)',default=r'(.*)\d-(\d\d\d\d\.\d\d)')
     parser.add_argument('--new_ver',help='Version of new indices (for alias)')
+    parser.add_argument('-p','--progress',help='Display progressbar',action='store_true')
 
     args = parser.parse_args()
-    
+
+    if args.progress and not args.quiet:
+        ## verbose logging will interrupt the progressbar if we don't wrap it
+        progressbar.streams.wrap_stderr()
+
     logfmt = "%(asctime)s [%(levelname)s %(name)s] %(message)s"
     if args.debug:
         logging.basicConfig(level=logging.DEBUG, format=logfmt)
@@ -141,11 +151,12 @@ if __name__=="__main__":
         sys.exit(1)
 
     processor = Processor(index=args.index,
-            url=args.url,
-            size=args.size,
-            close=args.close,
-            timeout=args.timeout,
-            alias=args.alias,
-            alias_regex=args.alias_regex,
-            new_ver=args.new_ver)
+                          url=args.url,
+                          size=args.size,
+                          close=args.close,
+                          timeout=args.timeout,
+                          alias=args.alias,
+                          alias_regex=args.alias_regex,
+                          new_ver=args.new_ver,
+                          progress=args.progress)
     processor.process()

--- a/gracc-reprocess/requirements.txt
+++ b/gracc-reprocess/requirements.txt
@@ -1,0 +1,3 @@
+elasticsearch > 5.0.0
+requests
+progressbar2


### PR DESCRIPTION
`gracc-reprocess` reads `RawXML` records from Elasticsearch and sends them to a GRACC collector.