### PR TITLE
add oneoff script to calculate median procs

### DIFF
--- a/gracc-oneoffs/correct-procs-purdue/get-median-ncpus.py
+++ b/gracc-oneoffs/correct-procs-purdue/get-median-ncpus.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+import json
+import time
+import datetime
+import statistics
+import collections
+import elasticsearch
+from elasticsearch_dsl import Search, A, Q
+
+
+gracc_url = 'https://gracc.opensciencegrid.org/q'
+
+jobs_raw_index = 'gracc.osg.raw-*'
+jobs_summary_index = 'gracc.osg.summary'
+
+
+def query_ncpus_counts():
+    es = elasticsearch.Elasticsearch([gracc_url])
+
+    starttime = datetime.datetime(2022, 5, 15)
+    endtime   = datetime.datetime(2022, 6, 15)
+    filters = (
+            Q('range', EndTime={'gte': starttime, 'lt': endtime })
+        &   Q('term', ResourceType='Batch')
+        &   Q('term', OIM_FQDN='hammer-osg.rcac.purdue.edu')
+    )
+
+    s = Search(using=es, index=jobs_summary_index)
+
+    s = s.query('bool', filter=[filters])
+    s.aggs.bucket('ncpus', 'terms', field='Processors', size=1000) \
+          .bucket('sumCount', 'sum', field='Count')
+
+    resp = s.execute()
+    aggs = resp.aggregations
+
+    #d    = aggs.to_dict()
+    #print(json.dumps(d, indent=2, sort_keys=1))
+
+    n_c = sorted( (b.key, int(b.sumCount.value)) for b in aggs.ncpus.buckets )
+
+    # [(1, 11), (2, 1712), (20, 2318), (40, 1156), (48, 865), (256, 329)]
+
+    return n_c
+
+
+def get_median_ncpus(n_c):
+    listo = ( [ncpus] * count for ncpus, count in n_c if ncpus > 1 )
+
+    median = statistics.median(sum(listo, []))
+
+    # 20
+
+    return median
+
+
+
+def main():
+    n_c = query_ncpus_counts()
+    median = get_median_ncpus(n_c)
+    print(median)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/gracc-oneoffs/correct-procs-purdue/same-core-corrections--send-updates.py
+++ b/gracc-oneoffs/correct-procs-purdue/same-core-corrections--send-updates.py
@@ -25,7 +25,7 @@ def main():
     #a = A('terms', field="LocalJobId", size=1000000)
     # Grab all the jobs from a specific probe
     probe_name = sys.argv[1]
-    s = Search(using=es, index=osg_raw_index)
+    s = Search(using=es, index=osg_raw_index).extra(from_=0, size=10000)
     s = s.filter('range', EndTime={'from': '2022-06-22', 'to': 'now'})
     s = s.filter('match', Processors=1)
     s = s.query('match', ProbeName=probe_name)
@@ -33,6 +33,7 @@ def main():
     print(response.success())
     print(response.took)
     print(response.hits.total.value)
+    print(len(response.hits.hits))
 
     cores = int(sys.argv[2])
     gain_in_coreHours = 0.0

--- a/gracc-oneoffs/correct-procs-purdue/same-core-corrections--send-updates.py
+++ b/gracc-oneoffs/correct-procs-purdue/same-core-corrections--send-updates.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+"""
+Query the ES index for all the jobs that have a specific probe name
+and send updates to gracc correcting the number of cores & CoreHours
+
+Has to be run on gracc host (hcc-gracc.unl.edu)
+
+Arguments:
+- probe_name: The name of the probe to look up
+- cores: The number of cores to set the job to
+"""
+import json
+import sys
+import elasticsearch
+from elasticsearch_dsl import Search, A, Q
+
+es = elasticsearch.Elasticsearch(
+        ['http://localhost:9200'], timeout=300, use_ssl=False)
+
+osg_raw_index = 'gracc.osg.raw-*'
+
+def main():
+    
+    #a = A('terms', field="LocalJobId", size=1000000)
+    # Grab all the jobs from a specific probe
+    probe_name = sys.argv[1]
+    s = Search(using=es, index=osg_raw_index)
+    s = s.filter('range', EndTime={'from': '2022-06-22', 'to': 'now'})
+    s = s.filter('match', Processors=1)
+    s = s.query('match', ProbeName=probe_name)
+    response = s.execute()
+    print(response.success())
+    print(response.took)
+    print(response.hits.total.value)
+
+    cores = int(sys.argv[2])
+    gain_in_coreHours = 0.0
+
+    # update each job with fixed Processors and recalculated CoreHours
+    for h in response.hits.hits:
+        d = h.to_dict()
+        job = d['_source']
+        job['Processors'] = cores
+        job['CoreHours'] = cores * (job['WallDuration'] / 3600)
+
+        r = es.update(index=d['_index'], id=d['_id'], body={'doc': job})
+
+        if r['result'] not in ['updated', 'noop']:
+            print('Error updating correction. Response: %s' % r)
+        else:
+            print('Correction %s updated.' % d['_id'])
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
this is just to drop my script somewhere

---

hard-coding date range 2022-05-15 - 2022-06-15, to capture about a month
worth of supposedly good data - the trouble starts around June 23, and
there are a large number of Processors=1 records prior to May 4.

Why median instead of average?  Per Brian B, we don't want a CPU cound
of 56.7 or similar.